### PR TITLE
Refactor: Remove jQuery dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "neon",
             "version": "2.0.0",
             "license": "ISC",
-            "dependencies": {
-                "jquery": "^3.7.1"
-            },
             "devDependencies": {
                 "eslint": "^9.32.0",
                 "jest": "^30.0.5",
@@ -630,9 +627,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-            "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+            "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -640,9 +637,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-            "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+            "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -677,9 +674,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz",
-            "integrity": "sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
+            "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -700,13 +697,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
-            "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+            "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.15.1",
+                "@eslint/core": "^0.15.2",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -1490,9 +1487,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.2.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-            "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+            "version": "24.2.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+            "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2312,9 +2309,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.25.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-            "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+            "version": "4.25.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
+            "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
             "dev": true,
             "funding": [
                 {
@@ -2332,8 +2329,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001726",
-                "electron-to-chromium": "^1.5.173",
+                "caniuse-lite": "^1.0.30001733",
+                "electron-to-chromium": "^1.5.199",
                 "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.3"
             },
@@ -2382,9 +2379,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001731",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-            "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+            "version": "1.0.30001734",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+            "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
             "dev": true,
             "funding": [
                 {
@@ -2704,9 +2701,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.198",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.198.tgz",
-            "integrity": "sha512-G5COfnp3w+ydVu80yprgWSfmfQaYRh9DOxfhAxstLyetKaLyl55QrNjx8C38Pc/C+RaDmb1M0Lk8wPEMQ+bGgQ==",
+            "version": "1.5.199",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.199.tgz",
+            "integrity": "sha512-3gl0S7zQd88kCAZRO/DnxtBKuhMO4h0EaQIN3YgZfV6+pW+5+bf2AdQeHNESCoaQqo/gjGVYEf2YM4O5HJQqpQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -2798,20 +2795,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
-            "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
+            "version": "9.33.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
+            "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.21.0",
-                "@eslint/config-helpers": "^0.3.0",
-                "@eslint/core": "^0.15.0",
+                "@eslint/config-helpers": "^0.3.1",
+                "@eslint/core": "^0.15.2",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.32.0",
-                "@eslint/plugin-kit": "^0.3.4",
+                "@eslint/js": "9.33.0",
+                "@eslint/plugin-kit": "^0.3.5",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -4297,12 +4294,6 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
-        "node_modules/jquery": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-            "license": "MIT"
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4595,9 +4586,9 @@
             "license": "MIT"
         },
         "node_modules/napi-postinstall": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
-            "integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+            "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
             "dev": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,5 @@
         "webpack": "^5.101.0",
         "webpack-cli": "^6.0.1"
     },
-    "dependencies": {
-        "jquery": "^3.7.1"
-    }
+    "dependencies": {}
 }

--- a/stdlib/widget.js
+++ b/stdlib/widget.js
@@ -1,7 +1,6 @@
 const { Class } = require('../neon.js');
 const { CustomEventSupport } = require('./custom_event_support.js');
 const { NodeSupport } = require('./node_support.js');
-const $ = require('jquery');
 
 const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
 
@@ -45,19 +44,20 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         __destroyed : false,
 
         init : function init(config) {
-            var property;
-
             Object.keys(config || {}).forEach(function (propertyName) {
                 this[propertyName] = config[propertyName];
             }, this);
 
             if (this.element == null) {
-                this.element = $(this.constructor.HTML.replace(/\s\s+/g, ''));
-                this.element.addClass(this.constructor.ELEMENT_CLASS);
+                const html = this.constructor.HTML.replace(/\s\s+/g, '');
+                const template = document.createElement('template');
+                template.innerHTML = html;
+                this.element = template.content.firstChild;
+                this.element.classList.add(this.constructor.ELEMENT_CLASS);
             }
 
             if (this.hasOwnProperty('className') === true) {
-                this.element.addClass(this.className);
+                this.element.classList.add(this.className);
             }
         },
 
@@ -69,7 +69,7 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         **/
         _activate : function _activate() {
             this.active = true;
-            this.element.addClass('active');
+            this.element.classList.add('active');
         },
 
         /**
@@ -104,7 +104,7 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         **/
         _deactivate : function _deactivate() {
             this.active = false;
-            this.element.removeClass('active');
+            this.element.classList.remove('active');
         },
 
         /**
@@ -139,7 +139,7 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         **/
         _enable : function _enable() {
             this.disabled = false;
-            this.element.removeClass('disable');
+            this.element.classList.remove('disable');
         },
 
         /**
@@ -167,7 +167,7 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         **/
         _disable : function _disable() {
             this.disabled = true;
-            this.element.addClass('disable');
+            this.element.classList.add('disable');
         },
 
         /**
@@ -259,9 +259,9 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
         This method should not be replaced by its children.
         @property render <public> [Function]
         @method
-        @argument element <required> [JQuery] (undefined) This is the element
+        @argument element <required> [HTMLElement] (undefined) This is the element
         into which the widget will be appended.
-        @argument beforeElement <optional> [jQuery] (undefined) this is the element
+        @argument beforeElement <optional> [HTMLElement] (undefined) this is the element
         that will be used as a reference to insert the widgets element. this argument
         must be a child of the "element" argument.
         @return this [Widget]
@@ -275,9 +275,9 @@ const Widget = Class('Widget').includes(CustomEventSupport, NodeSupport)({
                 beforeElement : beforeElement
             });
             if (beforeElement) {
-                this.element.insertBefore(beforeElement);
+                beforeElement.parentNode.insertBefore(this.element, beforeElement);
             } else {
-                this.element.appendTo(element);
+                element.appendChild(this.element);
             }
             this.dispatch('render');
             return this;


### PR DESCRIPTION
This commit removes the jQuery dependency from the project.

The `stdlib/widget.js` file has been refactored to use standard JavaScript DOM APIs instead of jQuery for all DOM manipulations. This includes creating elements, adding/removing classes, and appending/inserting elements into the DOM.

The `jquery` package has been removed from the `dependencies` in `package.json`, and the `package-lock.json` file has been updated accordingly.