### PR TITLE
Refactor: Rename CustomEvent to NeonCustomEvent

### DIFF
--- a/stdlib/custom_event_support.js
+++ b/stdlib/custom_event_support.js
@@ -1,5 +1,5 @@
 const { Module } = require('../neon.js');
-const { CustomEvent } = require('./custom_event.js');
+const { NeonCustomEvent } = require('./neon_custom_event.js');
 
 const CustomEventSupport = Module('CustomEventSupport')({
 
@@ -76,7 +76,7 @@ const CustomEventSupport = Module('CustomEventSupport')({
                 data.target = this;
             }
 
-            event         = new CustomEvent(type, data);
+            event         = new NeonCustomEvent(type, data);
             listeners     = this.eventListeners[type] || [];
             instance      = this;
 
@@ -166,7 +166,7 @@ const CustomEventSupport = Module('CustomEventSupport')({
                 data.target = this;
             }
 
-            event         = new CustomEvent(type, data);
+            event         = new NeonCustomEvent(type, data);
             listeners     = this.eventListeners[type] || [];
             instance      = this;
 

--- a/stdlib/index.js
+++ b/stdlib/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ...require('./custom_event.js'),
+  ...require('./neon_custom_event.js'),
   ...require('./custom_event_support.js'),
   ...require('./node_support.js'),
   ...require('./bubbling_support.js'),

--- a/stdlib/neon_custom_event.js
+++ b/stdlib/neon_custom_event.js
@@ -1,6 +1,6 @@
 const { Class } = require('../neon.js');
 
-const CustomEvent = Class('CustomEvent')({
+const NeonCustomEvent = Class('NeonCustomEvent')({
     prototype : {
         bubbles                       : true,
         cancelable                    : true,
@@ -39,5 +39,5 @@ const CustomEvent = Class('CustomEvent')({
 });
 
 module.exports = {
-  CustomEvent: CustomEvent
+  NeonCustomEvent: NeonCustomEvent
 };


### PR DESCRIPTION
I've renamed the `CustomEvent` class to `NeonCustomEvent` to avoid a naming conflict with the native DOM `CustomEvent`.

Here are the changes I made:
- I renamed the file `stdlib/custom_event.js` to `stdlib/neon_custom_event.js`.
- I renamed the `CustomEvent` class to `NeonCustomEvent` in `stdlib/neon_custom_event.js`.
- I updated the import and usage of `CustomEvent` in `stdlib/custom_event_support.js` to `NeonCustomEvent`.
- I updated the main export file `stdlib/index.js` to require the renamed module.